### PR TITLE
Minor changes

### DIFF
--- a/src/Inachis/CoreBundle/Entity/PageManager.php
+++ b/src/Inachis/CoreBundle/Entity/PageManager.php
@@ -3,8 +3,8 @@
 namespace Inachis\Component\CoreBundle\Entity;
 
 /**
- * Manager class for handling {@link {Page}
- * functions
+ * Used to manage interactions with the {@link Page}
+ * Entity/Repository
  */
 class PageManager extends AbstractManager
 {

--- a/src/Inachis/CoreBundle/Entity/TagManager.php
+++ b/src/Inachis/CoreBundle/Entity/TagManager.php
@@ -3,8 +3,7 @@
 namespace Inachis\Component\CoreBundle\Entity;
 
 /**
- * Manager class for handling {@link Tag}
- * functions
+ * Class for handling {@link Tag} specific Entity/Repository interactions
  */
 class TagManager extends AbstractManager
 {

--- a/src/Inachis/CoreBundle/Entity/Url.php
+++ b/src/Inachis/CoreBundle/Entity/Url.php
@@ -51,24 +51,19 @@ class Url
      */
     protected $modDate;
     /**
-     * Default constructor for Inachis\Core\URL entity
-     * @param string $type         The content type the URL is for
-     * @param int    $id           The ID of the content record
-     * @param string $link         The short link for the content
-     * @param bool   $convertLink Flag specifying if $link should be converted
-     * @param bool   $default      Flag specifying if this link is the canonical one
+     * Default constructor for Inachis\Core\URL entity - by default the
+     * URL will be specified as canonical. This can be overridden using
+     * {@link Url::setDefault}.
+     * @param string $type The content type the URL is for
+     * @param int $id The ID of the content record
+     * @param string $link The short link for the content
      */
-    public function __construct(
-        $type = '',
-        $id = '',
-        $link = '',
-        $convertLink = false,
-        $default = true
-    ) {
+    public function __construct($type = '', $id = '', $link = '')
+    {
         $this->setContentType($type);
         $this->setContentId($id);
-        $this->setLink($convertLink ? $this->urlify($link) : $link);
-        $this->setDefault($default);
+        $this->setLink($this->urlify($link));
+        $this->setDefault(true);
         $this->setCreateDateFromDateTime(new \DateTime('now'));
         $this->setModDateFromDateTime(new \DateTime('now'));
     }

--- a/src/Inachis/CoreBundle/Entity/UrlManager.php
+++ b/src/Inachis/CoreBundle/Entity/UrlManager.php
@@ -3,8 +3,7 @@
 namespace Inachis\Component\CoreBundle\Entity;
 
 /**
- * Manager class for handling {@link Url}
- * functions
+ * Manager class for handling {@link Url} interactions
  */
 class UrlManager extends AbstractManager
 {


### PR DESCRIPTION
Updated default constructor for `Url`
By default it no longer takes optional parameters for creating SEO-friendly URLs (defaults to making them so), and will now default to making the URL the canonical one. The reasoning behind this is to remove the single responsibility principle violation. Forcing the code to instead use functions for overriding these also makes the code more readable.

Also updated comments (again) on `*Manager` classes